### PR TITLE
Add babel in js:build-min task

### DIFF
--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -44,6 +44,9 @@ module.exports = function () {
     $.gulp.task('js:build-min', () => {
         return $.gulp.src([scriptsPATH.input + '*.js',
             '!' + scriptsPATH.input + 'libs.min.js'])
+            .pipe(babel({
+                presets: ['@babel/env']
+            }))
             .pipe(concat('main.min.js'))
             .pipe(uglify())
             .pipe($.gulp.dest(scriptsPATH.output))


### PR DESCRIPTION
Без этого не срабатывает uglify при наличии стрелочной функции, например. Соответственно, сборка не завершается